### PR TITLE
Add test template generation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/app/
+/tests/
+node_modules/

--- a/loom/generators/default.js
+++ b/loom/generators/default.js
@@ -25,10 +25,14 @@ generator.present = function(name) {
   };
 };
 
-generator.template = function(env) {
+generator.templates = function(env) {
   var plural = inflector.pluralize(env.name);
   var append = appendable(env.name) ? '_'+env.name : '';
-  return 'app/'+plural+'/'+env.name+append+'.js.hbs';
+
+  return [
+    'app/'+plural+'/'+env.name+append+'.js.hbs',
+    'tests/'+plural+'/'+env.name+append+'.test.js.hbs',
+  ]
 };
 
 function appendable(generatorName) {

--- a/loom/generators/template.js
+++ b/loom/generators/template.js
@@ -11,11 +11,11 @@ generator.before = function(env) {
   }
 };
 
-generator.template = function(env) {
+generator.templates = function(env) {
   if (isComponent(env.rawName)) {
-    return 'app/templates/components/component.hbs.hbs';
+    return ['app/templates/components/component.hbs.hbs'];
   } else {
-    return 'app/templates/template.hbs.hbs';
+    return ['app/templates/template.hbs.hbs'];
   }
 };
 

--- a/loom/templates/tests/controllers/controller_controller.test.js.hbs
+++ b/loom/templates/tests/controllers/controller_controller.test.js.hbs
@@ -1,0 +1,13 @@
+import {{objectName}} from '{{modulePath}}';
+
+var controller;
+
+QUnit.module('{{objectName}}', {
+  setup: function() {
+    controller = {{objectName}}.create();
+  }
+});
+
+test('it is a controller', function() {
+  ok(controller instanceof Ember.{{controllerType}}Controller, 'it is a controller');
+});

--- a/loom/templates/tests/helpers/helper.test.js.hbs
+++ b/loom/templates/tests/helpers/helper.test.js.hbs
@@ -1,0 +1,7 @@
+import helper from '{{modulePath}}';
+
+test('the truth', function() {
+  // var result = helper('something');
+  // equal(result, 'something');
+  ok(true);
+});

--- a/loom/templates/tests/mixins/mixin.test.js.hbs
+++ b/loom/templates/tests/mixins/mixin.test.js.hbs
@@ -1,0 +1,13 @@
+import {{objectName}} from '{{modulePath}}';
+
+var mixed;
+
+QUnit.module('{{objectName}}', {
+  setup: function() {
+    mixed = Ember.Object.createWithMixins({{objectName}});
+  }
+});
+
+test('the truth', function() {
+  ok(true);
+});

--- a/loom/templates/tests/models/model.test.js.hbs
+++ b/loom/templates/tests/models/model.test.js.hbs
@@ -1,0 +1,16 @@
+import helpers from '{{helpersPath}}';
+import {{objectName}} from '{{modulePath}}';
+
+var model, store;
+
+QUnit.module('{{objectName}}', {
+  setup: function() {
+    store = helpers.createStore();
+    model = store.createRecord({{objectName}});
+  }
+});
+
+test('it is a model', function() {
+  ok(model instanceof DS.Model, 'it is a model');
+});
+

--- a/loom/templates/tests/routes/route_route.test.js.hbs
+++ b/loom/templates/tests/routes/route_route.test.js.hbs
@@ -1,0 +1,13 @@
+import {{objectName}} from '{{modulePath}}';
+
+var route;
+
+QUnit.module('{{objectName}}', {
+  setup: function() {
+    route = {{objectName}}.create();
+  }
+});
+
+test('it is a route', function() {
+  ok(route instanceof Ember.Route, 'it is a route');
+});

--- a/loom/templates/tests/views/view_view.test.js.hbs
+++ b/loom/templates/tests/views/view_view.test.js.hbs
@@ -1,0 +1,13 @@
+import {{objectName}} from '{{modulePath}}';
+
+var view;
+
+QUnit.module('{{objectName}}', {
+  setup: function() {
+    view = {{objectName}}.create();
+  }
+});
+
+test('it is a view', function() {
+  ok(view instanceof Ember.View, 'it is a view');
+});

--- a/test/functional/controller.spec.js
+++ b/test/functional/controller.spec.js
@@ -3,23 +3,28 @@ var render = require('../helpers/render');
 var msg = require('loom/lib/message');
 var sinon = require('sinon');
 
+var baseTemplate = 'controllers/controller_controller';
+
 describe('controller', function() {
 
   it('renders regular controllers', function() {
     var locals = {objectName: 'ApplicationController'};
-    var expected = render('app/controllers/controller_controller.js.hbs', locals);
+    var expected = render('app/'+baseTemplate+'.js.hbs', locals);
+    expected += render('tests/'+baseTemplate+'.test.js.hbs', locals);
     loom('-sq controller application type:n').out.should.equal(expected);
   });
 
   it('renders object controllers', function() {
     var locals = {objectName: 'ApplicationController', type: 'Object'};
-    var expected = render('app/controllers/controller_controller.js.hbs', locals);
+    var expected = render('app/'+baseTemplate+'.js.hbs', locals);
+    expected += render('tests/'+baseTemplate+'.test.js.hbs', locals);
     loom('-sq controller application type:object').out.should.equal(expected);
   });
 
   it('renders array controllers', function() {
     var locals = {objectName: 'ApplicationController', type: 'Array'};
-    var expected = render('app/controllers/controller_controller.js.hbs', locals);
+    var expected = render('app/'+baseTemplate+'.js.hbs', locals);
+    expected += render('tests/'+baseTemplate+'.test.js.hbs', locals);
     loom('-sq controller application type:array').out.should.equal(expected);
   });
 

--- a/test/functional/helper.spec.js
+++ b/test/functional/helper.spec.js
@@ -6,6 +6,7 @@ describe('helper', function() {
   it('renders the template correctly', function() {
     var locals = { helperName: 'capitalize' };
     var expected = render('app/helpers/helper.js.hbs', locals);
+    expected += render('tests/helpers/helper.test.js.hbs', locals);
     loom('-sq helper capitalize').out.should.equal(expected);
   });
 

--- a/test/functional/mixins.spec.js
+++ b/test/functional/mixins.spec.js
@@ -6,6 +6,7 @@ describe('mixin', function() {
   it('renders the template correctly', function() {
     var locals = { objectName: 'TacoCartable' };
     var expected = render('app/mixins/mixin.js.hbs', locals);
+    expected += render('tests/mixins/mixin.test.js.hbs', locals);
     loom('-sq mixin taco_cartable').out.should.equal(expected);
   });
 

--- a/test/functional/model.spec.js
+++ b/test/functional/model.spec.js
@@ -12,6 +12,7 @@ describe('model', function() {
       ]
     };
     var expected = render('app/models/model.js.hbs', locals);
+    expected += render('tests/models/model.test.js.hbs', locals);
     loom('-sq model user name:string age:number').out.should.equal(expected);
   });
 

--- a/test/functional/route.spec.js
+++ b/test/functional/route.spec.js
@@ -6,6 +6,7 @@ describe('route', function() {
   it('renders the template correctly', function() {
     var locals = { objectName: 'TacoCartRoute' };
     var expected = render('app/routes/route_route.js.hbs', locals);
+    expected += render('tests/routes/route_route.test.js.hbs', locals);
     loom('-sq route taco_cart').out.should.equal(expected);
   });
 

--- a/test/functional/view.spec.js
+++ b/test/functional/view.spec.js
@@ -6,6 +6,7 @@ describe('view', function() {
   it('renders the template correctly', function() {
     var locals = { objectName: 'TacoCartView' };
     var expected = render('app/views/view_view.js.hbs', locals);
+    expected += render('tests/views/view_view.test.js.hbs', locals);
     loom('-sq view taco_cart').out.should.equal(expected);
   });
 

--- a/test/unit/default.spec.js
+++ b/test/unit/default.spec.js
@@ -47,12 +47,14 @@ describe('default generator', function() {
   describe('template', function() {
     it('finds the right template for appendable object types', function() {
       var env = {name: 'controller'};
-      generator.template(env).should.equal('app/controllers/controller_controller.js.hbs');
+      var expected = ['app/controllers/controller_controller.js.hbs', 'tests/controllers/controller_controller.test.js.hbs']
+      generator.templates(env).should.eql(expected);
     });
 
     it('finds the right template for non-appendable object types', function() {
       var env = {name: 'model'};
-      generator.template(env).should.equal('app/models/model.js.hbs');
+      var expected = ['app/models/model.js.hbs', 'tests/models/model.test.js.hbs']
+      generator.templates(env).should.eql(expected);
     });
   });
 });

--- a/test/unit/template.spec.js
+++ b/test/unit/template.spec.js
@@ -16,13 +16,13 @@ describe('template generator', function() {
 
   describe('template', function() {
     it('returns the component template for components', function() {
-      var template = generator.template({rawName: 'components/x-foo'});
-      template.should.equal('app/templates/components/component.hbs.hbs');
+      var template = generator.templates({rawName: 'components/x-foo'});
+      template.should.eql(['app/templates/components/component.hbs.hbs']);
     });
 
     it('returns the template template for non-components', function() {
-      var template = generator.template({rawName: 'foo'});
-      template.should.equal('app/templates/template.hbs.hbs');
+      var template = generator.templates({rawName: 'foo'});
+      template.should.eql(['app/templates/template.hbs.hbs']);
     });
   });
 
@@ -30,16 +30,16 @@ describe('template generator', function() {
 
     it('saves component templates to the right place', function() {
       var env = { args: ['components/x_foo'], rawName: 'components/x-foo', name: 'template'};
-      var template = generator.template(env);
+      var template = generator.templates(env);
       var path = generator.savePath(template, env);
       path.should.equal('app/templates/components/x-foo.hbs');
     });
 
     it('saves templates to the right place', function() {
       var env = { args: ['foo_bar'], rawName: 'foo_bar', name: 'template'};
-      var template = generator.template(env);
+      var template = generator.templates(env);
       var path = generator.savePath(template, env);
-      path.should.equal('app/templates/foo_bar.hbs');
+      path.should.eql('app/templates/foo_bar.hbs');
     });
   });
 });


### PR DESCRIPTION
This is not quite finished, but I figured I'd might as well get a PR going to get some feedback.

When we are ready to merge I can just squash everything down, but for now it is easier to pick through the commits if they are smaller.

The main issue that I have is how to get the module path of the object under test. In `ember-tools` this was provided by the `{{modulePath}}` variable (see [here](https://github.com/rpflorence/ember-tools/blob/tests/src/templates/generate/tests/controller.test.js.hbs#L1)), but with `loom` it is a bit more generalized. Suggestions?
